### PR TITLE
iOS Voice processing enabled setting bug fix

### DIFF
--- a/flutter_sound/ios/Classes/FlutterSoundPlayer.mm
+++ b/flutter_sound/ios/Classes/FlutterSoundPlayer.mm
@@ -124,7 +124,7 @@
 {
         flautoPlayer = [ [FlautoPlayer alloc] init: self];
         flutterSoundPlayerManager = pm;
-        bool voiceProcessing = (bool)call.arguments[@"voiceProcessing"];
+        bool voiceProcessing = [[call.arguments[@"voiceProcessing"] description] isEqualToString: @"1"];
         [flautoPlayer setVoiceProcessing: voiceProcessing];
         return [super init: call]; // Init Session
 }


### PR DESCRIPTION
Voice processing enabled setting bug fix: changed from bool cast that would **always evaluate to true/YES** no matter what was received from dart side, to NSString description compare that works properly now. This wrong mapping was causing the voice processing to always be `true` and this in turn caused crashes when using multiple instances of Flutter Sound Player (issue I've opened: [bug](https://github.com/Canardoux/flutter_sound/issues/900#issue-1248767871 )).