### PR TITLE
fix: correct log level key

### DIFF
--- a/flutter_sound_platform_interface/lib/method_channel_flutter_sound_recorder.dart
+++ b/flutter_sound_platform_interface/lib/method_channel_flutter_sound_recorder.dart
@@ -107,7 +107,7 @@ Future<dynamic>? channelMethodCallHandler(MethodCall call) {
 
         case "log":
         {
-          aRecorder!.log(Level.values[call.arguments['logLevel']], call.arguments['msg']);
+          aRecorder!.log(Level.values[call.arguments['level']], call.arguments['msg']);
         }
         break;
 


### PR DESCRIPTION
A log level is written to `'level'` not `'logLevel'`.