### PR TITLE
Implemented setSpeed for startPlayerFromStream

### DIFF
--- a/doc/pages/tau-api/player/set_speed.md
+++ b/doc/pages/tau-api/player/set_speed.md
@@ -17,8 +17,8 @@ The parameter is a floating point number greater than 0. It must be 0 to 1.0 to 
 The speed can be changed when player is running or before starting.
 If used before `startPlayer()`, the required speed is kept/delayed and set during the following call to `startPlayer()`.
 
-This verb is actually only for `startRecorder()` or `startPlayerFromBuffer()`.
-It does not work with `startPlayerFromMic()` nor `startPlayerFromStream()`.
+This verb is actually only for `startRecorder()`,  `startPlayerFromBuffer()` or `startPlayerFromStream()`.
+It does not work with `startPlayerFromMic()`.
 
 This verb works fine on
 - iOS

--- a/flutter_sound/android/src/main/java/com/dooboolab/fluttersound/FlutterSoundPlayer.java
+++ b/flutter_sound/android/src/main/java/com/dooboolab/fluttersound/FlutterSoundPlayer.java
@@ -182,7 +182,7 @@ public class FlutterSoundPlayer extends FlutterSoundSession implements  FlautoPl
 		Integer _codec = call.argument("codec");
 		t_CODEC codec = t_CODEC.values()[(_codec != null) ? _codec : 0];
 		byte[] dataBuffer = call.argument("fromDataBuffer");
-		Integer _blockSize = 4096;
+		Integer _blockSize = 8192;
 		if (call.argument("blockSize") != null) {
 			_blockSize = call.argument("blockSize");
 		}

--- a/flutter_sound/ios/Classes/FlutterSoundPlayer.mm
+++ b/flutter_sound/ios/Classes/FlutterSoundPlayer.mm
@@ -124,8 +124,9 @@
 {
         flautoPlayer = [ [FlautoPlayer alloc] init: self];
         flutterSoundPlayerManager = pm;
-        bool voiceProcessing = (bool)call.arguments[@"voiceProcessing"];
-        [flautoPlayer setVoiceProcessing: voiceProcessing];
+        NSNumber* voiceProcessing = (NSNumber*)call.arguments[@"voiceProcessing"];
+        bool voiceProcessingBool = ([voiceProcessing class] != [NSNull class]) ? [voiceProcessing intValue] != 0 ? true : false : false;
+        [flautoPlayer setVoiceProcessing: voiceProcessingBool];
         return [super init: call]; // Init Session
 }
 

--- a/flutter_sound/lib/public/flutter_sound_player.dart
+++ b/flutter_sound/lib/public/flutter_sound_player.dart
@@ -35,7 +35,7 @@ import 'package:synchronized/synchronized.dart';
 import '../flutter_sound.dart';
 
 /// The default blocksize used when playing from Stream.
-const _blockSize = 4096;
+const _blockSize = 8192;
 
 /// The possible states of the Player.
 enum PlayerState {

--- a/flutter_sound/lib/public/flutter_sound_player.dart
+++ b/flutter_sound/lib/public/flutter_sound_player.dart
@@ -532,7 +532,7 @@ class FlutterSoundPlayer implements FlutterSoundPlayerCallback {
     completer = _openPlayerCompleter;
     try {
       var state = await FlutterSoundPlayerPlatform.instance.openPlayer(this,
-          logLevel: _logLevel, voiceProcessing: enableVoiceProcessing);
+          logLevel: _logLevel, voiceProcessing: enableVoiceProcessing ? 1 : 0);
       _playerState = PlayerState.values[state];
       //isInited = success ?  Initialized.fullyInitialized : Initialized.notInitialized;
     } on Exception {

--- a/flutter_sound_platform_interface/lib/flutter_sound_player_platform_interface.dart
+++ b/flutter_sound_platform_interface/lib/flutter_sound_player_platform_interface.dart
@@ -136,7 +136,7 @@ abstract class FlutterSoundPlayerPlatform extends PlatformInterface {
     throw UnimplementedError('resetPlugin() has not been implemented.');
   }
 
-  Future<int> openPlayer(FlutterSoundPlayerCallback callback, {required Level logLevel, bool voiceProcessing=false})
+  Future<int> openPlayer(FlutterSoundPlayerCallback callback, {required Level logLevel, int voiceProcessing=0})
   {
     throw UnimplementedError('openPlayer() has not been implemented.');
   }

--- a/flutter_sound_platform_interface/lib/method_channel_flutter_sound_player.dart
+++ b/flutter_sound_platform_interface/lib/method_channel_flutter_sound_player.dart
@@ -196,7 +196,7 @@ Future<Map> invokeMethodMap (FlutterSoundPlayerCallback callback, String methodN
 
 
   @override
-  Future<int> openPlayer(FlutterSoundPlayerCallback callback, {required Level logLevel, bool voiceProcessing=false})
+  Future<int> openPlayer(FlutterSoundPlayerCallback callback, {required Level logLevel, int voiceProcessing=0})
   {
     return  invokeMethod( callback, 'openPlayer', {'logLevel': logLevel.index, 'voiceProcessing': voiceProcessing},) ;
   }

--- a/flutter_sound_web/lib/flutter_sound_player_web.dart
+++ b/flutter_sound_web/lib/flutter_sound_player_web.dart
@@ -183,7 +183,7 @@ class FlutterSoundPlayerWeb extends FlutterSoundPlayerPlatform //implements Flut
 
 
         @override
-        Future<int> openPlayer(FlutterSoundPlayerCallback callback, {required Level logLevel, bool voiceProcessing = false}) async
+        Future<int> openPlayer(FlutterSoundPlayerCallback callback, {required Level logLevel, int voiceProcessing=0}) async
         {
                 // openAudioSessionCompleter = new Completer<bool>();
                 // await invokeMethod( callback, 'initializeMediaPlayer', {'focus': focus.index, 'category': category.index, 'mode': mode.index, 'audioFlags': audioFlags, 'device': device.index, 'withUI': withUI ? 1 : 0 ,},) ;


### PR DESCRIPTION
Since I'm using this for a VoIP app I needed to speed up the playback rate of the stream when there is a delay between the two parties. Because of this I implemented it both for Android and iOS and increase the blockSize to 8192 on Android to allow up to x3 speed on the stream.