### PR TITLE
fix:Flauto.androidActivity caused memory leak

### DIFF
--- a/flutter_sound/android/src/main/java/com/dooboolab/fluttersound/FlutterSound.java
+++ b/flutter_sound/android/src/main/java/com/dooboolab/fluttersound/FlutterSound.java
@@ -61,11 +61,13 @@ public class FlutterSound
 	@Override
 	public void onDetachedFromEngine ( FlutterPlugin.FlutterPluginBinding binding )
 	{
+		
 	}
 
 	@Override
 	public void onDetachedFromActivity ()
 	{
+		Flauto.androidActivity = null;
 	}
 
 	@Override
@@ -74,13 +76,13 @@ public class FlutterSound
 			ActivityPluginBinding binding
 	                                                   )
 	{
-
+		Flauto.androidActivity = binding.getActivity ();
 	}
 
 	@Override
 	public void onDetachedFromActivityForConfigChanges ()
 	{
-
+		Flauto.androidActivity = null;
 	}
 
 	@Override


### PR DESCRIPTION
Flauto.androidActivity is  a static variable. It has a strong reference to the connected activity.
when the activity destoryed, memoy leaks.