### PR TITLE
uuid: ^4.3.3 updated

### DIFF
--- a/flutter_sound/pubspec.yaml
+++ b/flutter_sound/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   path_provider: ^2.0.2
   recase: ^4.0.0
-  uuid: ^3.0.1
+  uuid: ^4.3.3
   provider: ^6.0.0
   path: ^1.8.0
   synchronized: ^3.0.0


### PR DESCRIPTION
[3.0.1](https://pub.dev/packages/uuid/versions/3.0.1) is 2 year old version and all other libraries are updated and used > 4.0.0 